### PR TITLE
Localize for br-PT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
 	name: "LaunchAtLogin",
+	defaultLocalization: "en",
 	platforms: [
 		.macOS(.v13),
 		.macCatalyst(.v16)

--- a/Sources/LaunchAtLogin/LaunchAtLogin.swift
+++ b/Sources/LaunchAtLogin/LaunchAtLogin.swift
@@ -130,4 +130,13 @@ extension LaunchAtLogin.Toggle<Text> {
 		self.init(NSLocalizedString("toggle_label", bundle: .module, comment: "Text label for 'Launch at login' toggle"))
 	}
 }
+
+#Preview {
+	LaunchAtLogin.Toggle()
+		.environment(\.locale, .init(identifier: "en"))
+}
+#Preview {
+	LaunchAtLogin.Toggle()
+		.environment(\.locale, .init(identifier: "pt-BR"))
+}
 #endif

--- a/Sources/LaunchAtLogin/LaunchAtLogin.swift
+++ b/Sources/LaunchAtLogin/LaunchAtLogin.swift
@@ -107,8 +107,8 @@ extension LaunchAtLogin.Toggle<Text> {
 	- Parameters:
 		- titleKey: The key for the toggle's localized title, that describes the purpose of the toggle.
 	*/
-	public init(_ titleKey: LocalizedStringKey) {
-		label = Text(titleKey)
+	public init(_ titleKey: LocalizedStringKey, bundle: Bundle? = nil) {
+		label = Text(titleKey, bundle: bundle)
 	}
 
 	/**
@@ -127,7 +127,7 @@ extension LaunchAtLogin.Toggle<Text> {
 	Creates a toggle with the default title of `Launch at login`.
 	*/
 	public init() {
-		self.init(NSLocalizedString("toggle_label", bundle: .module, comment: "Text label for 'Launch at login' toggle"))
+		self.init("toggle_label", bundle: .module)
 	}
 }
 

--- a/Sources/LaunchAtLogin/LaunchAtLogin.swift
+++ b/Sources/LaunchAtLogin/LaunchAtLogin.swift
@@ -127,7 +127,7 @@ extension LaunchAtLogin.Toggle<Text> {
 	Creates a toggle with the default title of `Launch at login`.
 	*/
 	public init() {
-		self.init("Launch at login")
+		self.init(NSLocalizedString("toggle_label", bundle: .module, comment: "Text label for 'Launch at login' toggle"))
 	}
 }
 #endif

--- a/Sources/LaunchAtLogin/Localization/en.lproj/Localizable.strings
+++ b/Sources/LaunchAtLogin/Localization/en.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+"toggle_label" = "Launch at login";

--- a/Sources/LaunchAtLogin/Localization/pt-BR.lproj/Localizable.strings
+++ b/Sources/LaunchAtLogin/Localization/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+"toggle_label" = "Abrir no início da sessão";


### PR DESCRIPTION
Hello Sindre,

I looked through the issues on the original LaunchAtLogin repo and I didn't see any about localization, so I don't know if you hadn't added it yet for a reason, or if no one had bothered offering to add any.

I did see the comment about adding a custom Label "for localization purposes" in an [old PR](https://github.com/sindresorhus/LaunchAtLogin/issues/27), but honestly I don't see why not just use localization directly in the library.

I added br-PT because I speak it and support it in my apps. Hopefully others can add others over time, like have been added to [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts/tree/main/Sources/KeyboardShortcuts/Localization).

(I didn't bother added the `.localized` extension here because there is only one string to localize.)

Do you want me to add a comment to the README, like in [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts/blob/main/readme.md#localization)'?

And if you approve of adding this I can do the same for the original [repo](https://github.com/sindresorhus/LaunchAtLogin) as well.